### PR TITLE
Minor edits: python3 compatibility, dependencies update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
     - python-tornado
     - python-matplotlib 
     - python-tk
+    - python-dev
 
 language: python
 python:

--- a/c302/__init__.py
+++ b/c302/__init__.py
@@ -765,7 +765,7 @@ def generate(net_id,
                 pop0.properties.append(Property("neurotransmitter", str('; '.join(all_neuron_info[cell][3]))))  
             except Exception as e:
                 # It's only metadata...
-                print e
+                print (e)
                 pass
             
             pop0.instances.append(inst)


### PR DESCRIPTION
Since there's possibility to use Python3 already (test3.sh etc.) adding a fix for print function; as some C headers are used by BTrees and other packages adding a dependency for Travis (in a Python 3 environment that'd be python3-dev).