### PR TITLE
Recommending `pip install` rather than calling setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The full set of dependencies for c302 can be installed with the following (see a
 
     git clone https://github.com/openworm/c302.git
     cd c302
-    python setup.py install
+    pip install .
     owm bundle remote --user add ow 'https://raw.githubusercontent.com/openworm/owmeta-bundles/master/index.json'
 
 This will install c302 as well as all dependencies, including [pyNeuroML](https://github.com/NeuroML/pyNeuroML) and [owmeta](https://github.com/openworm/owmeta).


### PR DESCRIPTION
- `python setup.py install` installs pre-releases which breaks some
  basic examples in the README since owmeta publishes pre-release
  versions to PyPI (e.g., 0.14.0.dev20210412233714)