### PR TITLE
Continuous Integration: Replace 3.7 in CI Workflow Python Versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.9 ]
+        python-version: [ 3.8, 3.9 ]
         engine: [ jNeuroML, jNeuroML_NEURON, jNeuroML_validate ] #, NON_OMV_TESTS ]
 
     steps:


### PR DESCRIPTION
Replace Python 3.7 in the continuous integration workflow with Python 3.8. Python 3.7 is no longer available with the latest version of Ubuntu on GitHub Actions <sup>[1]</sup>. The lack of availability prevents the CI from running successfully. This commit will restore the CI workflow to operational success.


### Notes
1. [GitHub Actions version Manifest](https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json)