### PR TITLE
Test Open Worm Reader in Continuous Integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install OMV
       run: |
         pip install git+https://github.com/OpenSourceBrain/osb-model-validation
-        pip install scipy sympy matplotlib cython pandas tables
+        pip install scipy sympy matplotlib cython pandas tables pytest
     - name: Run OMV tests on engine ${{ matrix.engine }}
       run: |
         omv all -V --engine=${{ matrix.engine }}; export OMV_SUCCESS=$?; echo $OMV_SUCCESS
@@ -34,3 +34,8 @@ jobs:
         echo "Installing..."
         pip install .
         pip list
+    - name: Run unit tests
+      run: |
+        pip install .; pip install owmeta; pip install owmeta-core;
+        owm bundle remote --user add ow 'https://raw.githubusercontent.com/openworm/owmeta-bundles/master/index.json';
+        pytest tests/

--- a/tests/test_OpenWormReader.py
+++ b/tests/test_OpenWormReader.py
@@ -1,0 +1,30 @@
+import logging
+
+import pytest
+
+from c302.OpenWormReader import format_muscle_name
+
+
+class TestFormatMuscleName:
+    @pytest.mark.parametrize(
+        "name, name_expected, log_count_expected, assert_msg",
+        [
+            ("ADER", "ADER", 1, "Unknown muscle name format was not logged."),
+            ("MVL01", "MVL01", 0, "Known muscle name format was unexpectedly logged."),
+        ],
+    )
+    def test_should_log_unknown_name_format(
+        self,
+        name: str,
+        name_expected: str,
+        log_count_expected: int,
+        assert_msg: str,
+        caplog,
+    ) -> None:
+        caplog.set_level(logging.DEBUG)
+
+        format_muscle_name(name)
+
+        assert (
+            len(caplog.records) == log_count_expected
+        ), f"The incorrect quantity of logs was recorded."

--- a/tests/test_OpenWormReader.py
+++ b/tests/test_OpenWormReader.py
@@ -28,3 +28,29 @@ class TestFormatMuscleName:
         assert (
             len(caplog.records) == log_count_expected
         ), f"The incorrect quantity of logs was recorded."
+
+    @pytest.mark.parametrize(
+        "name, name_expected, assert_msg",
+        [
+            ("ADER", "ADER", "Unknown muscle name format was incorrectly formatted"),
+            ("MVL01", "MVL01", "Known muscle name format was incorrectly formatted"),
+            (
+                "VR01",
+                "MVR01",
+                "Known muscle name format missing 'M' was incorrectly formatted",
+            ),
+            ("MDL01", "MDL01", "Muscle name with 'DL' was incorrectly formatted"),
+            ("MDR01", "MDR01", "Muscle name with 'DR' was incorrectly formatted"),
+            (
+                "MVD01",
+                "MVD01",
+                "Unknown muscle name format with 'VD' was incorrectly formatted",
+            ),
+        ],
+    )
+    def test_should_format_muscle_name(
+        self, name: str, name_expected: str, assert_msg: str, caplog
+    ) -> None:
+        caplog.set_level(logging.DEBUG)
+        name_formatted: str = format_muscle_name(name)
+        assert name_formatted == name_expected, assert_msg


### PR DESCRIPTION
Test `OpenWormReader.py` in continuous integration. 

#9 recommends making a proper test suite to identify bugs. This is a first attempt at testing some of the functionality of `c302/OpenWormReader.py` to prevent regression, identify bugs, and document the functionality.